### PR TITLE
fix: eslint dependency problems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [10, 11, 12, 13, 14, 15, 16, 17]
+        node-version: [12, 13, 14, 15, 16, 17, 18]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-*
+* Removed node 10 and 11 and added node 18
 
 ### Fixed
 
-*
+* Fix eslint dependencies problems
 
 ## [0.2.4] - 2022-03-31
 

--- a/package.json
+++ b/package.json
@@ -35,19 +35,24 @@
     },
     "dependencies": {
         "consola": "^2.15.3",
-        "express": "^4.17.3",
+        "express": "^4.18.1",
         "hive-js-util": "^0.4.1",
         "request": "^2.88.2",
-        "yonius": "^0.11.5"
+        "yonius": "^0.11.7"
     },
     "devDependencies": {
-        "eslint": "^7.32.0",
-        "eslint-config-hive": "^0.5.3",
+        "eslint": "^8.16.0",
+        "eslint-config-hive": "^0.5.8",
+        "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-mocha": ">=10.0.0 && <10.0.3",
+        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-promise": "^6.0.0",
         "mocha": "^9.2.2",
-        "nodemon": "^2.0.15",
-        "npm-check-updates": "^12.5.4",
-        "prettier": "^2.6.1",
+        "nodemon": "^2.0.16",
+        "npm-check-updates": "^13.0.3",
+        "prettier": "^2.6.2",
         "prettier-config-hive": "^0.1.7",
-        "sort-package-json": "^1.55.0"
+        "sort-package-json": "^1.57.0"
     }
 }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Similar to https://github.com/ripe-tech/ripe-components-vue/pull/596 |
| Dependencies | |
| Decisions | - Port `eslint-config-hive` dependencies<br>- Lock `eslint-plugin-mocha` to `10.0.3` due to problem with mocha and ramda packages<br>- Removed node 10 and 11 and added node 18 |
| Animated GIF | -- |
